### PR TITLE
Replace category helptext with a nice tooltip

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -7,18 +7,18 @@ Colors and other variables
   --black: #000;
   --transparent: rgba(255, 255, 255, 0);
 
-  --golden-yellow: #FFCE4B;
-  --orange: #F78F31;
-  --light-green: #EDFFF5;
-  --contrast-green: #3BB54A;
-  --logo-green: #0B9A33;
+  --golden-yellow: #ffce4b;
+  --orange: #f78f31;
+  --light-green: #edfff5;
+  --contrast-green: #3bb54a;
+  --logo-green: #0b9a33;
 
-  --background-gray: #F0F0F0;
-  --lighter-gray: #F4F4F4;
+  --background-gray: #f0f0f0;
+  --lighter-gray: #f4f4f4;
   --dark-gray: #505050;
 
   --blue: #0b8ce9;
-  --dark-blue: #2B5399;
+  --dark-blue: #2b5399;
 
   --text-color: rgb(29, 29, 29);
   --link-color: var(--logo-green);
@@ -82,7 +82,9 @@ Minimal CSS reset
 https://www.joshwcomeau.com/css/custom-css-reset/
 */
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -91,19 +93,33 @@ body {
   display: grid;
 }
 
-img, picture, video, canvas, svg {
+img,
+picture,
+video,
+canvas,
+svg {
   max-width: 100%;
 }
 
-input, button, textarea, select {
+input,
+button,
+textarea,
+select {
   font: inherit;
 }
 
-p, h1, h2, h3, h4, h5, h6 {
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   overflow-wrap: break-word;
 }
 
-#root, #__next {
+#root,
+#__next {
   isolation: isolate;
 }
 
@@ -118,7 +134,12 @@ html {
   color: var(--color-text);
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-family-headline);
   color: var(--header-color-primary);
   font-weight: 700;
@@ -157,7 +178,6 @@ h6 {
   margin-bottom: var(--margin-bottom);
 }
 
-
 small {
   font-size: 0.75rem;
   line-height: 1.125rem;
@@ -167,13 +187,16 @@ strong {
   font-weight: 500;
 }
 
-a, a:visited {
+a,
+a:visited {
   color: var(--color-link);
 }
 
 /* Forms */
 
-input, textarea, button {
+input,
+textarea,
+button {
   border-radius: var(--border-radius);
   border: var(--border);
 }
@@ -182,10 +205,11 @@ input:focus,
 select:focus,
 textarea:focus,
 button:focus {
-    outline: var(--outline-input);
+  outline: var(--outline-input);
 }
 
-input, textarea {
+input,
+textarea {
   padding: 0.3rem 0.75rem 0.3rem 0.75rem;
 }
 
@@ -194,11 +218,13 @@ label {
 }
 
 .required label:after {
-  content:" *";
+  content: " *";
   color: var(--color-required-label);
 }
 
-input, textarea, button[type=submit] {
+input,
+textarea,
+button[type="submit"] {
   margin-bottom: var(--margin-bottom);
 }
 
@@ -223,7 +249,8 @@ form ul.errorlist.nonfield li {
 :where(a),
 .button-link {
   color: var(--link-color);
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     color: var(--link-focus-color);
   }
 }
@@ -236,6 +263,7 @@ form ul.errorlist.nonfield li {
   padding-block: 12px;
   padding-inline: 24px;
   text-align: center;
+  cursor: pointer;
   &:is(a) {
     display: inline-block;
   }
@@ -402,7 +430,7 @@ thead tr {
 
 /* Temp new stuff - some we might keep when we replace this base.css */
 fieldset {
-  border:none;
+  border: none;
   padding-left: 0;
 }
 
@@ -413,7 +441,7 @@ label {
   font-size: var(--step-0);
 }
 
-p.tagline{
+p.tagline {
   font-size: var(--step-2);
 }
 
@@ -429,9 +457,12 @@ p.tagline{
 input + label.radiogrid {
   display: inline-block;
   background: var(--lighter-gray);
-  padding-block:5px;
+  padding-block: 5px;
   padding-inline: 8px;
   min-width: 150px;
+  cursor: pointer;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
 }
 
 input:hover + label.radiogrid {
@@ -448,14 +479,50 @@ input:checked + label.radiogrid {
 }
 
 div#datatype_help_grid {
-  display:grid;
-  grid-template-columns:3fr 1fr;
-  margin-bottom:20px;"
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  margin-bottom: 20px;
 }
 
 div#datatype_radio_grid {
-  display:grid;
-  grid-template-columns: repeat(3,1fr);
-  grid-auto-rows:minmax(40px,auto);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: minmax(40px, auto);
 }
 
+.with-tooltip {
+  position: relative;
+}
+
+/* The tooltip box */
+.with-tooltip::before {
+  content: attr(data-text);
+  position: absolute;
+  display: none;
+  top: 0;
+  transform: translate(-50%, calc(-100% - 6px));
+  left: 50%;
+  padding: 10px 15px;
+  background: var(--dark-gray);
+  color: #fff;
+  min-width: 200px;
+  font-size: var(--step--1);
+  border-radius: var(--border-radius);
+}
+
+/* The arrow */
+.with-tooltip::after {
+  content: "";
+  display: none;
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -6px);
+  border: 5px solid var(--dark-gray);
+  border-color: var(--dark-gray) transparent transparent transparent;
+}
+
+.with-tooltip:hover::before,
+.with-tooltip:hover::after {
+  display: block;
+}

--- a/static/js/query_form.js
+++ b/static/js/query_form.js
@@ -4,123 +4,131 @@
 // some of which are invalid for the content type chosen.
 
 function setupDropdown(dropdownElement, possibleValues) {
-    dropdownElement.innerHTML = "";
-    let defaultOption = document.createElement('option');
-    defaultOption.text = 'Select an option';
-    defaultOption.value = '';
-    dropdownElement.add(defaultOption, dropdownElement.options[0]);
-    dropdownElement.selectedIndex = 0;
-    let uniqueValues = [...new Set(possibleValues)];
+  dropdownElement.innerHTML = "";
+  let defaultOption = document.createElement("option");
+  defaultOption.text = "Select an option";
+  defaultOption.value = "";
+  dropdownElement.add(defaultOption, dropdownElement.options[0]);
+  dropdownElement.selectedIndex = 0;
+  let uniqueValues = [...new Set(possibleValues)];
 
-    if (uniqueValues.length > 0) {
-        uniqueValues.forEach((value) => {
-            const option = document.createElement("option");
-            option.text = value;
-            option.value = value;
-            dropdownElement.appendChild(option);
-        });
-        dropdownElement.disabled = false;
-    } else {
-        dropdownElement.disabled = true;
-    }
-
+  if (uniqueValues.length > 0) {
+    uniqueValues.forEach((value) => {
+      const option = document.createElement("option");
+      option.text = value;
+      option.value = value;
+      dropdownElement.appendChild(option);
+    });
+    dropdownElement.disabled = false;
+  } else {
+    dropdownElement.disabled = true;
+  }
 }
 
 function changeHelp(new_text) {
-  let help_text = document.getElementById('help_text');
+  let help_text = document.getElementById("help_text");
   help_text.innerText = new_text;
 }
 
-
-document.addEventListener('DOMContentLoaded', function() {
-
-  var hidden_form_items = document.getElementsByClassName('formstarthidden');
+document.addEventListener("DOMContentLoaded", function () {
+  var hidden_form_items = document.getElementsByClassName("formstarthidden");
   for (item of hidden_form_items) {
     item.style.display = "none";
-  };
-
-
-  document.querySelectorAll("label.radiogrid").forEach(function(label) {
-    label.addEventListener("mouseover", function() {
-      // do something when the button is clicked
-      changeHelp(label.title);
-    });
-  });
+  }
 
   let query_form = document.forms["query_form"];
   let sourceDropdown = document.getElementById("id_datasource");
   let destDropdown = document.getElementById("id_datadest");
 
   function get_selected_datatype() {
-    let selected_radio_item = query_form.querySelector('input[name="datatype"]:checked');
+    let selected_radio_item = query_form.querySelector(
+      'input[name="datatype"]:checked'
+    );
     return selected_radio_item === null ? null : selected_radio_item.value;
   }
 
   if (!(sourceDropdown && destDropdown)) {
-    console.error("Missing expected form elements - id_datasource and id_datadest");
+    console.error(
+      "Missing expected form elements - id_datasource and id_datadest"
+    );
     return;
   }
 
   function saveFormState() {
-    if(get_selected_datatype()) {
+    if (get_selected_datatype()) {
       try {
-        sessionStorage.setItem('selectedType', get_selected_datatype());
-        sessionStorage.setItem('selectedSource', sourceDropdown.value);
-        sessionStorage.setItem('selectedDest', destDropdown.value);
+        sessionStorage.setItem("selectedType", get_selected_datatype());
+        sessionStorage.setItem("selectedSource", sourceDropdown.value);
+        sessionStorage.setItem("selectedDest", destDropdown.value);
       } catch (e) {
-        console.log("Session storage not available; form contents may reset")
+        console.log("Session storage not available; form contents may reset");
       }
-
     }
   }
 
   // Add an event listener so that when the content type is chosen, a list of known sources is populated
   // for the next step
   let last_datatype = null;
-  query_form.addEventListener("change", function() {
-    var hidden_form_items = document.getElementsByClassName('formstarthidden');
+  query_form.addEventListener("change", function () {
+    var hidden_form_items = document.getElementsByClassName("formstarthidden");
     for (item of hidden_form_items) {
-        item.style.display = "block";
-    };
+      item.style.display = "block";
+    }
     new_datatype = get_selected_datatype();
-    if(new_datatype != null && new_datatype != last_datatype) {
+    if (new_datatype != null && new_datatype != last_datatype) {
       last_datatype = new_datatype;
-      datatype_lookup_key = new_datatype.replace(/_/g, ' ');
-      setupDropdown(sourceDropdown, Object.keys(queryStructure[datatype_lookup_key]));
+      datatype_lookup_key = new_datatype.replace(/_/g, " ");
+      setupDropdown(
+        sourceDropdown,
+        Object.keys(queryStructure[datatype_lookup_key])
+      );
       setupDropdown(destDropdown, []);
-    };
-  })
-
+    }
+  });
 
   // Then when the source for data is chosen, a list of destinations
   sourceDropdown.addEventListener("change", function () {
     saveFormState();
-    datatype_lookup_key = get_selected_datatype().replace(/_/g, ' ');
-    setupDropdown(destDropdown, queryStructure[datatype_lookup_key][sourceDropdown.value]);
+    datatype_lookup_key = get_selected_datatype().replace(/_/g, " ");
+    setupDropdown(
+      destDropdown,
+      queryStructure[datatype_lookup_key][sourceDropdown.value]
+    );
   });
 
-  destDropdown.addEventListener('change', saveFormState);
+  destDropdown.addEventListener("change", saveFormState);
 
   // Restore form state
   function restoreFormState() {
     try {
-      let selectedType = sessionStorage.getItem('selectedType');
+      let selectedType = sessionStorage.getItem("selectedType");
       if (selectedType) {
-        let todo_radio_item = query_form.querySelector('input[value=selectedType]');
+        let todo_radio_item = query_form.querySelector(
+          "input[value=selectedType]"
+        );
         todo_radio_item.select();
-        setupDropdown(sourceDropdown, Object.keys(queryStructure[selectedType]));
+        setupDropdown(
+          sourceDropdown,
+          Object.keys(queryStructure[selectedType])
+        );
       }
-      let selectedSource = sessionStorage.getItem('selectedSource');
+      let selectedSource = sessionStorage.getItem("selectedSource");
       if (selectedSource && selectedSource !== sourceDropdown.value) {
-          sourceDropdown.value = selectedSource;
-          setupDropdown(destDropdown, queryStructure[selectedType][selectedSource]);
+        sourceDropdown.value = selectedSource;
+        setupDropdown(
+          destDropdown,
+          queryStructure[selectedType][selectedSource]
+        );
       }
-      let selectedDest = sessionStorage.getItem('selectedDest');
+      let selectedDest = sessionStorage.getItem("selectedDest");
       if (selectedDest && selectedDest !== destDropdown.value) {
-          destDropdown.value = selectedDest;
+        destDropdown.value = selectedDest;
       }
     } catch (e) {
-      console.log("Error restoring form state - sessionStorage may not be available", e)
+      console.log(
+        "Error restoring form state - sessionStorage may not be available",
+        e
+      );
     }
   }
 
@@ -128,11 +136,9 @@ document.addEventListener('DOMContentLoaded', function() {
   restoreFormState();
 
   let askForArticle = document.getElementById("askforarticle");
-  askForArticle.style.display='none';
+  askForArticle.style.display = "none";
   let didNotFind = document.getElementById("didnotfind");
-  didNotFind.addEventListener('click', function() {
-      askForArticle.style.display='inline';
-
-  })
-
+  didNotFind.addEventListener("click", function () {
+    askForArticle.style.display = "inline";
+  });
 });

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -34,9 +34,8 @@
                 {% for datatype, help in datatype_help.items %}
                     <div>
                         <input style="display:none;" type="radio" name="datatype"
-                               id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'
-                               title="{{ help }}">
-                        <label class='radiogrid' for="{{ datatype.split|join:"_" }}" title="{{ help }}">{{ datatype }}</label>
+                               id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'>
+                        <label class='radiogrid with-tooltip' for="{{ datatype.split|join:"_" }}" data-text="{{ help }}">{{ datatype }}</label>
                     </div>
                 {% endfor %}
                 </div>


### PR DESCRIPTION
Resolves #9.

(Sorry for the messy diff; I forgot I had my formatter turned on!)

Adds a nice CSS tooltip to the data categories and removes the changing text to the right of the buttons.

![Screenshot from 2024-02-16 11-23-51](https://github.com/dtinit/portmap/assets/6510436/75fd69e4-4272-4b47-a343-4b8d35891479)

See https://blog.logrocket.com/creating-beautiful-tooltips-with-only-css/ for implementation details! The short version is I used a custom `data-text` attribute to define the tooltip content, and created a `.with-tooltip` class which gives us an easy way to put tooltips on whatever we want.

I also:
- Rounded the category buttons because everybody loves rounded rectangles and it matches our other buttons
- Change the cursor for the category buttons and our other buttons to `pointer` since that's the standard signifier for clickable elements

PS. This is a solid iteration over what we have, but as we think about mobile (#12) we might reconsider using tooltips to convey this information—they're tricky to get right on touch devices and even the most touch-friendly implementations feel a little compromised to me. I went ahead and implemented this for now since it was a good intro to the project and hardly took any time!