### PR TITLE
Fix mobile styles for category grid and feedback form

### DIFF
--- a/portmap/core/forms.py
+++ b/portmap/core/forms.py
@@ -61,7 +61,7 @@ class UseCaseFeedbackForm(forms.ModelForm):
             and interoperability features that would be most helpful."""
         }
         widgets = {
-            "explanation": forms.Textarea(attrs={"cols": 60, "rows": 4}),
+            "explanation": forms.Textarea(attrs={"cols": '', "rows": 4}),
             "datatype": forms.HiddenInput(),
             "source": forms.HiddenInput(),
             "destination": forms.HiddenInput()

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -213,8 +213,8 @@ textarea {
   padding: 0.3rem 0.75rem 0.3rem 0.75rem;
 }
 
-label {
-  margin-bottom: var(--margin-bottom-small);
+textarea {
+  width: 100%;
 }
 
 .required label:after {
@@ -459,10 +459,11 @@ input + label.radiogrid {
   background: var(--lighter-gray);
   padding-block: 5px;
   padding-inline: 8px;
-  min-width: 150px;
+  text-align: center;
   cursor: pointer;
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
+  width: 100%;
 }
 
 input:hover + label.radiogrid {
@@ -479,15 +480,23 @@ input:checked + label.radiogrid {
 }
 
 div#datatype_help_grid {
-  display: grid;
-  grid-template-columns: 3fr 1fr;
   margin-bottom: 20px;
 }
 
 div#datatype_radio_grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: minmax(40px, auto);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 20px;
+  gap: 0.5rem;
+}
+
+.radiogrid-container {
+  min-width: 200px;
+}
+
+.datatype {
+  min-width: 100px;
 }
 
 .with-tooltip {
@@ -505,9 +514,10 @@ div#datatype_radio_grid {
   padding: 10px 15px;
   background: var(--dark-gray);
   color: #fff;
-  min-width: 200px;
+  min-width: 250px;
   font-size: var(--step--1);
   border-radius: var(--border-radius);
+  text-align: left;
 }
 
 /* The arrow */
@@ -525,4 +535,11 @@ div#datatype_radio_grid {
 .with-tooltip:hover::before,
 .with-tooltip:hover::after {
   display: block;
+}
+
+@media (max-width: 600px) {
+  .radiogrid-container,
+  label.radiogrid {
+    width: 100%;
+  }
 }

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -32,16 +32,13 @@
                 <p>Select kind of data to see what articles we have:</p>
                 <div id="datatype_radio_grid">
                 {% for datatype, help in datatype_help.items %}
-                    <div>
+                    <div class="radiogrid-container">
                         <input style="display:none;" type="radio" name="datatype"
                                id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'>
                         <label class='radiogrid with-tooltip' for="{{ datatype.split|join:"_" }}" data-text="{{ help }}">{{ datatype }}</label>
                     </div>
                 {% endfor %}
                 </div>
-            </div>
-            <div id="help_text" style="font-style:italic;text-align: right;">
-
             </div>
         </div>
         <div class="formstarthidden">


### PR DESCRIPTION
Fixes #12.

Updates the category list to wrap at smaller widths, and the textareas to take up the full width of their parents instead of using `cols`

![Screenshot from 2024-02-16 15-58-13](https://github.com/dtinit/portmap/assets/6510436/db8b7be4-4999-479f-b311-f0f3d78b165d)
![Screenshot from 2024-02-16 15-58-54](https://github.com/dtinit/portmap/assets/6510436/f143c9a0-e3ee-441c-82d2-aa0b61fd4c2a)
![Screenshot from 2024-02-16 16-00-21](https://github.com/dtinit/portmap/assets/6510436/df6079ca-6cf3-4fbf-89ee-91397b201d7d)
