### PR TITLE
Disable Find Articles button until a source is selected

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -293,6 +293,11 @@ form ul.errorlist.nonfield li {
   }
 }
 
+.button:disabled {
+  opacity: 0.6;
+  pointer-events: none; /* disable hovering, clicking, etc */
+}
+
 .button-link {
   background: none;
   border: none;

--- a/static/js/query_form.js
+++ b/static/js/query_form.js
@@ -36,9 +36,10 @@ document.addEventListener("DOMContentLoaded", function () {
     item.style.display = "none";
   }
 
-  let query_form = document.forms["query_form"];
-  let sourceDropdown = document.getElementById("id_datasource");
-  let destDropdown = document.getElementById("id_datadest");
+  const query_form = document.forms["query_form"];
+  const sourceDropdown = document.getElementById("id_datasource");
+  const destDropdown = document.getElementById("id_datadest");
+  const submitButton = document.getElementById("query-form-submit-button");
 
   function get_selected_datatype() {
     let selected_radio_item = query_form.querySelector(
@@ -83,6 +84,7 @@ document.addEventListener("DOMContentLoaded", function () {
         Object.keys(queryStructure[datatype_lookup_key])
       );
       setupDropdown(destDropdown, []);
+      submitButton.removeAttribute("disabled");
     }
   });
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -43,13 +43,13 @@
         </div>
         <div class="formstarthidden">
             <label for="id_datasource">Where is it now?</label>
-            <select name="datasource" disabled id="id_datasource"></select>
+            <select name="datasource" disabled id="id_datasource" required></select>
         </div>
         <div class="formstarthidden">
             <label for="id_datadest">Destination:</label>
             <select name="datadest" disabled id="id_datadest"></select>
         </div>
-        <button class='button' type="submit">{% translate "Find Article" %}</button>
+        <button class='button' type="submit" id="query-form-submit-button"disabled>{% translate "Find Article" %}</button>
     </form>
 
 <div style="display:block;">


### PR DESCRIPTION
Resolves #14.

Disables the Find Articles button until a data type has been selected, then uses it form validation until a source has been selected.

(I'm not sure if destination is supposed to be required or not @lisad? For what it's worth, it apparently doesn't _need_ to be selected [see recording below]. If it's supposed to be required, I can update this to make it)

[Screencast from 2024-02-20 15-46-07.webm](https://github.com/dtinit/portmap/assets/6510436/bacba13e-7373-45e3-9318-47cd6c272711)
