### PR TITLE
Unnest CSS rules

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -246,13 +246,13 @@ form ul.errorlist.nonfield li {
 
 /* || BUTTONS AND LINKS */
 
-:where(a),
 .button-link {
   color: var(--link-color);
-  &:hover,
-  &:focus {
-    color: var(--link-focus-color);
-  }
+}
+
+.button-link:hover,
+.button-link:focus {
+  color: var(--link-focus-color);
 }
 
 .button {
@@ -264,33 +264,36 @@ form ul.errorlist.nonfield li {
   padding-inline: 24px;
   text-align: center;
   cursor: pointer;
-  &:is(a) {
-    display: inline-block;
-  }
-  &:not(.button-outline) {
-    background: var(--logo-green);
-    border: 2px solid transparent;
-    color: var(--white);
-    &:hover,
-    &:focus {
-      background-color: var(--transparent);
-      border: 2px solid var(--logo-green);
-      color: var(--logo-green);
-    }
-  }
-  &-outline {
-    background-color: var(--transparent);
-    border: 2px solid var(--logo-green);
-    color: var(--logo-green);
-    &:hover,
-    &:focus {
-      background-color: var(--logo-green);
-      color: var(--white);
-    }
-  }
-  &:is(a) {
-    text-decoration: none;
-  }
+}
+
+.button-outline {
+  background-color: var(--transparent);
+  border: 2px solid var(--logo-green);
+  color: var(--logo-green);
+}
+
+.button-outline:hover,
+.button-outline:focus {
+  background-color: var(--logo-green);
+  color: var(--white);
+}
+
+.button:is(a) {
+  text-decoration: none;
+  display: inline-block;
+}
+
+.button:not(.button-outline) {
+  background: var(--logo-green);
+  border: 2px solid transparent;
+  color: var(--white);
+}
+
+.button:not(.button-outline):hover,
+.button:not(.button-outline):focus {
+  background-color: var(--transparent);
+  border: 2px solid var(--logo-green);
+  color: var(--logo-green);
 }
 
 .button:disabled {


### PR DESCRIPTION
Resolves #26.
Relates to #23.

Just unnests some CSS rules since the support isn't quite good enough yet. I also dropped a rule that applied to `:where(a)` since it wasn't doing anything (there's another rule matching just `a` which will always take precedence over `:where(a)`)