### PR TITLE
Add article index page and provide path for search engines to crawl it

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -104,9 +104,14 @@ def find_articles(request):
 
         if form['datatype']:
 
+            # If a datatype wasn't specified, show a list of every article
             if not form.data.get('datatype'):
-                form = QueryIndexForm(data=None, datatypes=datatypes)
-                return index(request)
+                context = {
+                    'articles': Article.objects.order_by("title").all(),
+                    'title': 'All articles',
+                    'use_case_form': UseCaseFeedbackForm(data=None, datatype='None', source='', destination='')
+                }
+                return TemplateResponse(request, "core/article_list.html", context)
             datatype_joined = " ".join(form.data['datatype'].split("_"))
             possible_articles = Article.objects.filter(datatype__contains=datatype_joined,
                                                        sources__contains=form.data['datasource'],
@@ -124,7 +129,7 @@ def find_articles(request):
                                                        datatype=form.data['datatype'],
                                                        source=form.data['datasource'],
                                                        destination=form.data['datadest'])
-                context = {'articles': possible_articles, 'use_case_form': use_case_feedback}
+                context = {'articles': possible_articles, 'use_case_form': use_case_feedback, 'title': 'Relevant Articles'}
                 return TemplateResponse(request, "core/article_list.html", context)
 
     else:

--- a/templates/core/article_list.html
+++ b/templates/core/article_list.html
@@ -5,10 +5,9 @@
 {% block content %}
 <section class="page page--wide">
     {% include "includes/messages.html" %}
-    <p>We found multiple articles with this query.</p>
     <table>
    <tr>
-       <th>Articles</th>
+       <th>{% if title %}{{title}}{% else %}Articles{% endif %}</th>
    </tr>
    {% for item in articles %}
        <tr>
@@ -16,6 +15,7 @@
        </tr>
    {% endfor %}
 </table>
+{% if use_case_form %}
 <hr>
     <p>If none of these solutions works for you, we'd love to learn why!</p>
     <form method="post" action="usecase_feedback" id="multiple_option_feedback_form">
@@ -23,5 +23,6 @@
         {{ use_case_form }}
         <button class="button button-outline" type="submit">{% translate "Give Feedback" %}</button>
     </form>
+{% endif %}
 </section>
 {% endblock content %}

--- a/templates/core/article_list.html
+++ b/templates/core/article_list.html
@@ -17,7 +17,7 @@
 </table>
 {% if use_case_form %}
 <hr>
-    <p>If none of these solutions works for you, we'd love to learn why!</p>
+    <p>If none of these solutions work for you, we'd love to learn why!</p>
     <form method="post" action="usecase_feedback" id="multiple_option_feedback_form">
         {% csrf_token %}
         {{ use_case_form }}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -53,7 +53,8 @@
         </div>
         <button class='button' type="submit" id="query-form-submit-button"disabled>{% translate "Find Article" %}</button>
     </form>
-
+    <br />
+    Or you can <a href="/find_articles">browse all articles.</a>
 <div style="display:block;">
     <hr>
     <p id="didnotfind">Can't see the option you're looking for? <i data-lucide="arrow-down-square"></i></p>


### PR DESCRIPTION
Closes #40.

Creates a list of all articles when `/find_articles` isn't provided a datatype:
![Screenshot from 2024-03-05 12-22-52](https://github.com/dtinit/portmap/assets/6510436/5351a794-78e7-47e6-8ee6-da66f26875c0)

Also adds a link to it from the home page (below "Find Article"):
![Screenshot from 2024-03-05 12-21-51](https://github.com/dtinit/portmap/assets/6510436/9c651277-0239-4c85-b022-3bfa1d208779)

As the number of articles grows, we'll need to build on this (grouping articles by category, etc), but I think this is the perfect first step to make the articles crawlable.