### PR TITLE
Add "About" page and a nav bar

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -42,6 +42,9 @@ def _get_index_context():
                'datatypes': query_structure.keys(),
                'datatype_help': datatype_help_cleaned}
 
+def about(request):
+    return TemplateResponse(request, "core/about.html")
+
 @login_required
 def user_settings(request):
     form = UpdateAccountForm(instance=request.user)

--- a/portmap/urls.py
+++ b/portmap/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path("articles/<article_name>/", views.display_article, name="display_article"),
     path("find_articles", views.find_articles, name="find_articles"),
     # core
+    path("about", views.about, name="about"),
     path("", views.index, name="index"),
 ]
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -413,7 +413,7 @@ thead tr {
   margin-bottom: 40px;
   padding-right: clamp(10px, 5%, 60px);
   padding-left: clamp(10px, 5%, 60px);
-  padding-top: clamp(10px, 5%, 60px);
+  padding-top: 15px;
   padding-bottom: 2rem;
   background-color: white;
   border-radius: var(--border-radius);
@@ -549,6 +549,27 @@ div#datatype_radio_grid {
 .with-tooltip:hover::before,
 .with-tooltip:hover::after {
   display: block;
+}
+
+.nav-bar {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 3rem;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--dark-gray);
+}
+
+.nav-bar a {
+  text-decoration: none;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: inherit;
+}
+
+.nav-bar a:hover,
+.nav-bar a.active {
+  color: var(--color-link);
 }
 
 /* mobile styles */

--- a/templates/core/about.html
+++ b/templates/core/about.html
@@ -1,0 +1,13 @@
+{% extends '_base.html' %}
+{% load static %}
+{% load i18n %}
+{% block full_title %}{{ PROJECT_NAME }}{% endblock full_title %}
+{% block content %}
+<section class="page page--wide">
+    {% include "includes/nav-bar.html" with route="about" %}
+    {% include "includes/messages.html" %}
+    <h1>About</h1>
+    <p>This Web site was built and is maintained by <a href="https://dtinit.org">DTI</a> to promote gathering and sharing information about how users can transfer their own data between online services. This supports our mission of promoting portability in order to provide real options to users.</p>
+    <p>The content in this Web site belongs to the public. It's hosted in a <a href="https://github.com/dtinit/portability-articles">GitHub repository</a> under <a href="http://creativecommons.org/publicdomain/zero/1.0">Creative Commons license</a>. Contributions are welcome!</p>
+</section>
+{% endblock content %}

--- a/templates/core/article.html
+++ b/templates/core/article.html
@@ -7,6 +7,7 @@
 {% block full_title %}{{ article.title }}{% endblock full_title %}
 {% block content %}
 <section class="page page--wide">
+    {% include "includes/nav-bar.html" %}
     {% include "includes/messages.html" %}
 
     {{ article_body_html }}

--- a/templates/core/article_list.html
+++ b/templates/core/article_list.html
@@ -4,6 +4,7 @@
 {% block full_title %}{{ PROJECT_NAME }}{% endblock full_title %}
 {% block content %}
 <section class="page page--wide">
+    {% include "includes/nav-bar.html" with route="articles" %}
     {% include "includes/messages.html" %}
     <table>
    <tr>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -8,6 +8,7 @@
 {% block content %}
 
 <section class="page page--wide">
+    {% include "includes/nav-bar.html" with route="home" %}
     {% include "includes/messages.html" %}
     <header><img style="float:left;max-width:300px;padding-right:20px;" src="https://dtinit.org/images/blog/Firefly-Train-Schedule.jpg"/>
     <h1>

--- a/templates/core/thankyou.html
+++ b/templates/core/thankyou.html
@@ -7,6 +7,7 @@
 
 {% block content %}
 <section class="page page--wide">
+    {% include "includes/nav-bar.html" %}
 <h1>Thank you!</h1>
 
 <p>    <i data-lucide="heart" color="#e64e33"></i>

--- a/templates/includes/nav-bar.html
+++ b/templates/includes/nav-bar.html
@@ -1,0 +1,7 @@
+<nav class="nav-bar">
+    <a href="/" class="{% if route == 'home' %}active{%endif%}">Home</a>
+    <a href="/about" class="{% if route == 'about' %}active{%endif%}">About</a>
+    <a href="/find_articles" class="{% if route == 'articles' %}active{%endif%}"
+        >Articles</a
+    >
+</nav>


### PR DESCRIPTION
Closes #47 (I took some creative liberties!)

- Adds an "About" page with the information from #47.
- Adds a top nav where the most important pages can be accessed from every page. This nav matches the one on dtinit.org

![Screenshot from 2024-03-05 16-17-36](https://github.com/dtinit/portmap/assets/6510436/d1f804eb-4697-4c33-ae8b-7e6c5b02e237)
![Screenshot from 2024-03-05 16-17-27](https://github.com/dtinit/portmap/assets/6510436/47c38aee-d2b2-42c8-8fbd-559e9f6a1e71)
