### PR TITLE
Article feedback UI/UX improvements

### DIFF
--- a/portmap/core/forms.py
+++ b/portmap/core/forms.py
@@ -4,6 +4,9 @@ from django.forms.renderers import TemplatesSetting
 
 from .models import User, UseCaseFeedback
 
+# The included RadioSelect widget wraps the input element inside of a label,
+# which makes it difficult to style the label based on the input's checked state.
+# This custom widget structures the label and input as siblings instead.
 class UnwrappedRadioSelect(forms.RadioSelect):
     option_template_name = "forms/widgets/unwrapped_radio_option.html"
 

--- a/portmap/core/forms.py
+++ b/portmap/core/forms.py
@@ -4,6 +4,8 @@ from django.forms.renderers import TemplatesSetting
 
 from .models import User, UseCaseFeedback
 
+class UnwrappedRadioSelect(forms.RadioSelect):
+    option_template_name = "forms/widgets/unwrapped_radio_option.html"
 
 class CustomFormRenderer(TemplatesSetting):
     form_template_name = "forms/custom.html"
@@ -42,9 +44,9 @@ class QueryIndexForm(forms.Form):
         self.label_suffix = ' '
 
 class ArticleFeedbackForm(forms.Form):
-    CHOICES = [('happy', '<span>yes</span>'),
-               ('sad', '<span>no</span>')]
-    reaction = forms.ChoiceField(label="Did this article help?", widget=forms.RadioSelect, choices=CHOICES)
+    CHOICES = [('happy', 'Yes'),
+               ('sad', 'No')]
+    reaction = forms.ChoiceField(label="Did this article help?", widget=UnwrappedRadioSelect, choices=CHOICES)
     explanation = forms.CharField(widget=forms.Textarea,
                                   required=False,
                                   label="What is your use case? What would make this article better?")

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -572,6 +572,51 @@ div#datatype_radio_grid {
   color: var(--color-link);
 }
 
+#id_reaction {
+  display: flex;
+  width: auto;
+  position: relative;
+}
+
+/* we're hiding the actual radio input */
+#id_reaction input[type='radio'] {
+  opacity: 0;
+  position: absolute;
+  bottom: -10px;
+}
+
+#id_reaction label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  border: 1px solid #aaa;
+  cursor: pointer;
+}
+
+#id_reaction input[type='radio']:checked + label {
+  background: #eee;
+}
+
+#id_reaction > div:first-of-type input[type='radio']:checked + label {
+  color: var(--logo-green);
+}
+
+#id_reaction > div:last-of-type input[type='radio']:checked + label {
+  color: darkred;
+}
+
+#id_reaction > div:first-of-type label {
+  border-top-left-radius: var(--border-radius);
+  border-bottom-left-radius: var(--border-radius);
+}
+
+#id_reaction > div:last-of-type label {
+  border-top-right-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  border-left: 0;
+}
+
 /* mobile styles */
 @media (max-width: 600px) {
   .radiogrid-container,

--- a/static/js/article.js
+++ b/static/js/article.js
@@ -8,23 +8,32 @@
   }
 
   document.addEventListener('DOMContentLoaded', function () {
-    let happyButton = document.getElementById('id_reaction_0');
-    let sadButton = document.getElementById('id_reaction_1');
+    const happyButton =
+      document.getElementById('id_reaction_0').nextElementSibling;
+    const sadButton =
+      document.getElementById('id_reaction_1').nextElementSibling;
 
-    happyButton.nextSibling.replaceWith(lucideElement('smile')); // replaces "yes" string with smily face
-    sadButton.nextSibling.replaceWith(lucideElement('frown')); // replaces "no" with frown
+    // replaces "yes" string with smily face
+    happyButton.innerHTML = '';
+    happyButton.appendChild(lucideElement('smile'));
+
+    // replaces "no" with frown
+    sadButton.innerHTML = '';
+    sadButton.appendChild(lucideElement('frown'));
 
     lucide.createIcons();
 
-    let explanationText = document.getElementById('id_explanation');
+    const explanationText = document.getElementById('id_explanation');
     explanationText.hidden = true;
-    let explanationLabel =
+    const explanationLabel =
       explanationText.parentElement.getElementsByTagName('label')[0];
     explanationLabel.style.visibility = 'hidden';
 
-    sadButton.addEventListener('change', function () {
-      explanationLabel.style.visibility = 'visible';
-      explanationText.hidden = false;
+    [happyButton, sadButton].forEach((button) => {
+      button.previousElementSibling.addEventListener('change', function () {
+        explanationLabel.style.visibility = 'visible';
+        explanationText.hidden = false;
+      });
     });
   });
 })();

--- a/templates/forms/widgets/unwrapped_radio_option.html
+++ b/templates/forms/widgets/unwrapped_radio_option.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}{% if widget.wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{% endif %}{% if widget.wrap_label %} {{ widget.label }}</label>{% endif %}


### PR DESCRIPTION
Closes #34.
Closes #36.

Visual improvements to the article feedback buttons. Also makes sure the explanation field reveals for both positive and negative feedback.

Before:
![Screenshot from 2024-03-11 12-57-32](https://github.com/dtinit/portmap/assets/6510436/071eb615-0ac6-4a90-b7db-22e42b1d598e)

After:
![Screenshot from 2024-03-11 12-54-03](https://github.com/dtinit/portmap/assets/6510436/73bcbdbe-3d29-4c84-8efc-8157bd9433bb)
![Screenshot from 2024-03-11 12-54-13](https://github.com/dtinit/portmap/assets/6510436/002a6075-5134-4895-8f7c-37bcf9d0f4dd)
![Screenshot from 2024-03-11 12-54-19](https://github.com/dtinit/portmap/assets/6510436/a105a451-d9c9-4d87-927c-d47d1f884396)
