### PR TITLE
Improve signifier for index feedback form reveal

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -310,12 +310,6 @@ form ul.errorlist.nonfield li {
   text-decoration: underline;
 }
 
-#didnotfind {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
 input[type='checkbox'] {
   display: inline-block;
   width: 1.15em;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -302,11 +302,18 @@ form ul.errorlist.nonfield li {
 }
 
 .button-link {
+  cursor: pointer;
   background: none;
   border: none;
   font-size: 1rem;
   padding: 0;
   text-decoration: underline;
+}
+
+#didnotfind {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 input[type='checkbox'] {

--- a/static/js/query_form.js
+++ b/static/js/query_form.js
@@ -169,10 +169,11 @@
       safelySetSessionStorageItem('selectedDest', destDropdown.value);
     });
 
-    let askForArticle = document.getElementById('askforarticle');
+    const askForArticle = document.getElementById('askforarticle');
     askForArticle.style.display = 'none';
-    let didNotFind = document.getElementById('didnotfind');
+    const didNotFind = document.getElementById('didnotfind');
     didNotFind.addEventListener('click', function () {
+      didNotFind.remove();
       askForArticle.style.display = 'inline';
     });
   });

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -56,10 +56,9 @@
     </form>
     <br />
     Or you can <a href="/find_articles">browse all articles.</a>
-<div style="display:block;">
     <hr>
-    <p id="didnotfind">Can't see the option you're looking for? <i data-lucide="arrow-down-square"></i></p>
-</div>
+    <br />
+    <button id="didnotfind" class="button-link">Can't see the option you're looking for?</button>
     <div id="askforarticle">
     <p>Please let us know what we should add articles about - or consider contributing at
         <a href="https://github.com/dtinit/portability-articles">our content repository</a>!</p>


### PR DESCRIPTION
Closes #35.

Makes it easier to see that you can click on "Can't find what you're looking for?" Also removes the button on click, so the form effectively replaces it rather than be appended below it.

**Before**
![Screenshot from 2024-03-12 13-55-11](https://github.com/dtinit/portmap/assets/6510436/36ca4d22-703c-48b7-8336-68d2343b2adf)

**After**
![Screenshot from 2024-03-12 13-55-19](https://github.com/dtinit/portmap/assets/6510436/2bf7abb3-d73f-457a-9235-0782b63be77d)
