### PR TITLE
Design updates

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -33,7 +33,7 @@ def _get_index_context():
     query_form = QueryIndexForm(data=None, datatypes=query_structure.keys())
     feedback_form = UseCaseFeedbackForm(data=None, datatype='None', source='', destination='')
     datatype_help = GithubClient().get_datatype_help()
-    datatype_help_cleaned = {datatype: f"{datatype}: {datatype_help.get(datatype, '')}" for datatype in query_structure.keys()}
+    datatype_help_cleaned = {datatype: f"{datatype_help.get(datatype, '')}" for datatype in query_structure.keys()}
 
 
     return {'form': query_form,

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -623,8 +623,8 @@ div#datatype_radio_grid {
 }
 
 select {
-  padding: calc(var(--padding-base) / 2) var(--padding-base);
-  border-radius: 10rem; /* This just needs to be bigger than then height of any select
+  padding: calc(var(--padding-base) / 2);
+  border-radius: var(--border-radius);
 }
 
 /* mobile styles */

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -13,7 +13,6 @@ Colors and other variables
   --contrast-green: #3bb54a;
   --logo-green: #0b9a33;
 
-  --background-gray: #f0f0f0;
   --lighter-gray: #f4f4f4;
   --dark-gray: #505050;
 
@@ -29,7 +28,7 @@ Colors and other variables
   --font-family-headline: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --color-text: var(--text-color);
   --color-primary: rgb(82, 84, 188);
-  --color-background: var(--background-gray);
+  --color-background: var(--white);
   --color-link: var(--logo-green);
   --color-success: rgb(214, 250, 214);
   --color-info: rgb(243, 238, 194);
@@ -416,9 +415,6 @@ thead tr {
   padding-left: clamp(10px, 5%, 60px);
   padding-top: 15px;
   padding-bottom: 2rem;
-  background-color: white;
-  border-radius: var(--border-radius);
-  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
 }
 
 .page--wide {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -341,15 +341,11 @@ table {
 
 th,
 td {
-  padding: var(--padding-base);
+  padding: var(--padding-base) 0;
 }
 
 tr {
   background-color: var(--color-tr-background);
-}
-
-tr:nth-child(even) td {
-  background-color: var(--color-tr-alternate-background);
 }
 
 thead tr {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -484,7 +484,7 @@ input:checked + label.radiogrid {
   border: 2px solid var(--color-link);
   /* We're increasing the border by 1px but don't want the layout to shift,
    * so decrease the padding by 1px to make up for it */
-  padding: calc(0.5rem - 1px) calc(1rem - 1px);
+  padding: calc(inherit - 1px);
 }
 
 .radiogrid__title {
@@ -624,7 +624,7 @@ div#datatype_radio_grid {
 
 select {
   padding: calc(var(--padding-base) / 2) var(--padding-base);
-  border-radius: 10rem;
+  border-radius: 10rem; /* This just needs to be bigger than then height of any select
 }
 
 /* mobile styles */

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -14,6 +14,7 @@ Colors and other variables
   --logo-green: #0b9a33;
 
   --lighter-gray: #f4f4f4;
+  --medium-gray: #bbbbbb;
   --dark-gray: #505050;
 
   --blue: #0b8ce9;
@@ -457,16 +458,21 @@ p.tagline {
   font-style: italic;
 }
 
-input + label.radiogrid {
-  display: inline-block;
-  background: var(--lighter-gray);
-  padding-block: 5px;
-  padding-inline: 8px;
-  text-align: center;
+.radiogrid {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem; /* make sure this matches the checked style */
   cursor: pointer;
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
-  width: 100%;
+  border: 1px solid var(--medium-gray);
+  /* Use half of the available width (minus the gap)
+   * so they're in rows of 2 */
+  width: calc(50% - 0.25rem);
+  height: 7rem;
+  box-sizing: border-box;
 }
 
 input:hover + label.radiogrid {
@@ -474,8 +480,20 @@ input:hover + label.radiogrid {
 }
 
 input:checked + label.radiogrid {
-  background: var(--color-primary);
-  color: white;
+  background: var(--light-green);
+  border: 2px solid var(--color-link);
+  /* We're increasing the border by 1px but don't want the layout to shift,
+   * so decrease the padding by 1px to make up for it */
+  padding: calc(0.5rem - 1px) calc(1rem - 1px);
+}
+
+.radiogrid__title {
+  font-weight: 500;
+}
+
+.radiogrid__help {
+  font-size: var(--step--2);
+  color: var(--dark-gray);
 }
 
 .formstarthidden {
@@ -492,14 +510,6 @@ div#datatype_radio_grid {
   align-items: center;
   margin-bottom: 20px;
   gap: 0.5rem;
-}
-
-.radiogrid-container {
-  min-width: 200px;
-}
-
-.datatype {
-  min-width: 100px;
 }
 
 .data-dropdowns {
@@ -614,9 +624,9 @@ div#datatype_radio_grid {
 
 /* mobile styles */
 @media (max-width: 600px) {
-  .radiogrid-container,
   label.radiogrid {
     width: 100%;
+    height: 6rem;
   }
 
   .data-dropdowns {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -622,6 +622,11 @@ div#datatype_radio_grid {
   border-left: 0;
 }
 
+select {
+  padding: calc(var(--padding-base) / 2) var(--padding-base);
+  border-radius: 10rem;
+}
+
 /* mobile styles */
 @media (max-width: 600px) {
   label.radiogrid {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -407,14 +407,10 @@ thead tr {
   min-width: 270px;
   max-width: 600px;
   width: calc(100% - 20px);
-  margin-top: clamp(0px, 5%, 40px);
+  margin-top: 5px;
   margin-right: auto;
   margin-left: auto;
   margin-bottom: 40px;
-  padding-right: clamp(10px, 5%, 60px);
-  padding-left: clamp(10px, 5%, 60px);
-  padding-top: 15px;
-  padding-bottom: 2rem;
 }
 
 .page--wide {
@@ -431,6 +427,12 @@ thead tr {
   border: 1px solid var(--color-danger);
   border-radius: var(--border-radius);
   padding: var(--padding-base);
+}
+
+.hero-image {
+  float: left;
+  max-width: 300px;
+  padding-right: 20px;
 }
 
 /* Temp new stuff - some we might keep when we replace this base.css */
@@ -623,5 +625,12 @@ div#datatype_radio_grid {
 
   .data-dropdowns {
     flex-direction: column;
+  }
+
+  .hero-image {
+    max-width: none;
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 20px;
   }
 }

--- a/static/js/query_form.js
+++ b/static/js/query_form.js
@@ -156,6 +156,7 @@
         lastDatatype = newDatatype;
         populateSourceListForDatatype(newDatatype);
         safelySetSessionStorageItem('selectedType', newDatatype);
+        sourceDropdown.scrollIntoView({ behavior: 'smooth' });
       }
     });
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -33,11 +33,14 @@
                 <p>Select kind of data to see what articles we have:</p>
                 <div id="datatype_radio_grid">
                 {% for datatype, help in datatype_help.items %}
-                    <div class="radiogrid-container">
-                        <input style="display:none;" type="radio" name="datatype"
-                               id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'>
-                        <label class='radiogrid with-tooltip' for="{{ datatype.split|join:"_" }}" data-text="{{ help }}">{{ datatype }}</label>
-                    </div>
+                    <input style="display:none;" type="radio" name="datatype"
+                             id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'>
+                    <label
+                        class='radiogrid'
+                        for="{{ datatype.split|join:"_" }}">
+                        <div class="radiogrid__title">{{ datatype }}</div>
+                        <div class="radiogrid__help">{{ help }}</div>
+                    </label>
                 {% endfor %}
                 </div>
             </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -10,7 +10,7 @@
 <section class="page page--wide">
     {% include "includes/nav-bar.html" with route="home" %}
     {% include "includes/messages.html" %}
-    <header><img style="float:left;max-width:300px;padding-right:20px;" src="https://dtinit.org/images/blog/Firefly-Train-Schedule.jpg" alt="A person checking a transit schedule"/>
+    <header><img class="hero-image" src="https://dtinit.org/images/blog/Firefly-Train-Schedule.jpg" alt="A person checking a transit schedule"/>
     <h1>
         Data Portability Map
     </h1>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -58,7 +58,7 @@
         <button class='button' type="submit" id="query-form-submit-button"disabled>{% translate "Find Article" %}</button>
     </form>
     <br />
-    Or you can <a href="/find_articles">browse all articles.</a>
+    Or you can <a href="/find_articles">browse all the articles.</a>
     <hr>
     <br />
     <button id="didnotfind" class="button-link">Can't see the option you're looking for?</button>


### PR DESCRIPTION
Closes #60.

- Removes the faux document style to make the design cleaner and free up the total padding and margins around the document (especially on mobile)
  - Also moves the header/nav up to the top of the page
- Changes the datatype selection radios to be bigger and include the help text, removing the need for tooltips which are always awkward with touch inputs
  - Also removes the "[[DATATYPE]]: ..." label from the help text which was a bit redundant
- Styles the selects to match other elements
- Removes the striping on the article list table

I'm open to feedback & suggestions of course! (@Gogo-ug1?)

![Screenshot from 2024-03-18 12-33-43](https://github.com/dtinit/portmap/assets/6510436/50adf8fb-9fcf-4817-ac59-4376e9870fc5)
![Screenshot from 2024-03-18 12-48-38](https://github.com/dtinit/portmap/assets/6510436/0d789e86-2330-4e05-b568-362d12f0566e)
![Screenshot from 2024-03-18 12-49-11](https://github.com/dtinit/portmap/assets/6510436/9dc1e4b3-1977-4715-a3ff-972ec6fd1d40)
![Screenshot from 2024-03-18 12-34-42](https://github.com/dtinit/portmap/assets/6510436/5dbe5365-54c5-4617-b575-4af06d47aea6)
![Screenshot from 2024-03-18 12-34-50](https://github.com/dtinit/portmap/assets/6510436/26b83142-3d38-455c-bbaf-e41234ee536e)
