### PR TITLE
Alex 66 data type icons

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -461,9 +461,8 @@ p.tagline {
 
 .radiogrid {
   display: flex;
-  justify-content: center;
-  flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 1rem; /* Probably make this the same as horizontal padding */
   padding: 0.5rem 1rem; /* make sure this matches the checked style */
   cursor: pointer;
   border-radius: var(--border-radius);
@@ -488,11 +487,22 @@ input:checked + label.radiogrid {
   padding: calc(0.5rem - 1px) calc(1rem - 1px);
 }
 
-.radiogrid__title {
+.radiogrid__icon {
+  width: 3.5rem;
+}
+
+.radiogrid__info {
+  flex-direction: column;
+  gap: 0.25rem;
+  flex-grow: 1;
+  width: 100%;
+}
+
+.radiogrid__info__title {
   font-weight: 500;
 }
 
-.radiogrid__help {
+.radiogrid__info__help {
   font-size: var(--step--2);
   color: var(--dark-gray);
 }
@@ -638,6 +648,10 @@ footer {
   label.radiogrid {
     width: 100%;
     height: 6rem;
+  }
+
+  .radiogrid__icon {
+    width: 2.5rem;
   }
 
   .data-dropdowns {

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -32,16 +32,16 @@
             <div>
                 <p>Select kind of data to see what articles we have:</p>
                 <div id="datatype_radio_grid">
-                {% for datatype, help in datatype_help.items %}
+                {% for datatype in datatypes %}
                     <input style="display:none;" type="radio" name="datatype"
-                             id={{ datatype.split|join:"_" }} value='{{ datatype.split|join:"_" }}'>
+                             id={{ datatype.id }} value='{{ datatype.id }}'>
                     <label
                         class='radiogrid'
-                        for="{{ datatype.split|join:"_" }}">
-                        <i data-lucide="volume-2" class="radiogrid__icon"></i>
+                        for="{{ datatype.id }}">
+                        <i data-lucide="{{ datatype.icon }}" class="radiogrid__icon"></i>
                         <div class="radiogrid__info">
-                            <div class="radiogrid__info__title">{{ datatype }}</div>
-                            <div class="radiogrid__info__help">{{ help }}</div>
+                            <div class="radiogrid__info__title">{{ datatype.name }}</div>
+                            <div class="radiogrid__info__help">{{ datatype.help }}</div>
                         </div>
                     </label>
                 {% endfor %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -38,8 +38,11 @@
                     <label
                         class='radiogrid'
                         for="{{ datatype.split|join:"_" }}">
-                        <div class="radiogrid__title">{{ datatype }}</div>
-                        <div class="radiogrid__help">{{ help }}</div>
+                        <i data-lucide="volume-2" class="radiogrid__icon"></i>
+                        <div class="radiogrid__info">
+                            <div class="radiogrid__info__title">{{ datatype }}</div>
+                            <div class="radiogrid__info__help">{{ help }}</div>
+                        </div>
                     </label>
                 {% endfor %}
                 </div>
@@ -81,7 +84,7 @@
 
 <script src="{% static 'js/query_form.js' %}"></script>
 <script>
-  lucide.createIcons();
+ lucide.createIcons();
 </script>
 
 {% endblock content %}


### PR DESCRIPTION
Closes #66.

Adds nice Lucide icons for each datatype. Falls back to a generic [file](https://lucide.dev/icons/file) icon if there's not one specified for a datatype.

Feel free to suggest [others](https://lucide.dev/icons/)!

![Screenshot from 2024-04-10 11-46-53](https://github.com/dtinit/portmap/assets/6510436/2ba5a006-18c0-4234-a3f1-aaf4c48f570c)
![Screenshot from 2024-04-10 11-47-08](https://github.com/dtinit/portmap/assets/6510436/5a282a59-8884-470f-a6d5-44ffe5e077ba)
