### PR TITLE
Enable better cache support for index page with `cache-control` headers

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext as _
 from django.utils.safestring import mark_safe
+from django.views.decorators.cache import cache_control
 from .forms import UpdateAccountForm, QueryIndexForm, ArticleFeedbackForm, UseCaseFeedbackForm
 from .models import User, Article, Feedback, QueryLog, UseCaseFeedback, DataType
 from portmap.slack import notify
@@ -40,6 +41,7 @@ def ux_requires_post(function):
         return redirect("index")
     return _wrap_requires_post
 
+@cache_control(max_age=24 * 60 * 60, public=True) # Allow caching for 24 hours (in seconds)
 def index(request):
     return TemplateResponse(request, "core/index.html", _get_index_context())
 

--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -68,6 +68,7 @@ def _get_index_context():
                 'datatypes': datatypes
             }
 
+@cache_control(max_age=24 * 60 * 60, public=True) # Allow caching for 24 hours (in seconds)
 def about(request):
     return TemplateResponse(request, "core/about.html")
 


### PR DESCRIPTION
Closes #82.
Sets `cache-control` to `public` with a maximum age of 24 hours for the index page and about page. I skipped the article pages because the caching could interfere with view tracking.