### PR TITLE
Adding TrackArticleView to Admin View

### DIFF
--- a/portmap/core/admin.py
+++ b/portmap/core/admin.py
@@ -61,5 +61,5 @@ class CustomUserAdmin(UserAdmin):
     ]
 
 @register(TrackArticleView, site=admin_site)
-class TestingArticleViewAdmin(admin.ModelAdmin):
-    list_display = ("article", "article_path", "visited_directly", "external_referrer", )
+class TrackArticleViewAdmin(admin.ModelAdmin):
+    list_display = ("article", "article_path", "visited_directly", "external_referrer", )  

--- a/portmap/core/admin.py
+++ b/portmap/core/admin.py
@@ -24,7 +24,7 @@ admin_site._registry.update(admin.site._registry)
 
 @register(Article, site=admin_site)
 class ArticleAdmin(admin.ModelAdmin):
-    list_display = ("name", "datatype", "title", "source_list", "destination_list")
+    list_display = ("name", "datatype", "title", "source_list", "destination_list", "view_count", )
 
     def get_urls(self):
         urls = super().get_urls()
@@ -60,23 +60,6 @@ class CustomUserAdmin(UserAdmin):
         "last_login",
     ]
 
-@register(DataType, site=admin_site)
-class DataTypeAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name', 'helpText')
-
 @register(TrackArticleView, site=admin_site)
-class TrackArticleViewAdmin(admin.ModelAdmin):
-    list_display = ('article_path', "count", "visited_directly", "external_referrer",)
-    aggregated_counts = {}
-
-    def count(self, object):
-        matched_item = next(item for item in self.aggregated_counts if item["article_path"] == object.article_path)
-        return matched_item["count"]
-
-    def get_queryset(self, request):
-        qs = super(TrackArticleViewAdmin, self).get_queryset(request)
-        self.aggregated_counts = list(qs.values("article_path").annotate(count=Count('article_path')))
-        return qs.annotate(count=Count('article_path'))
-
-    def get_object(self, request, object_id, from_field=None):
-        return TrackArticleView.objects.filter(id=object_id).first()
+class TestingArticleViewAdmin(admin.ModelAdmin):
+    list_display = ("article", "article_path", "visited_directly", "external_referrer", )

--- a/portmap/core/models.py
+++ b/portmap/core/models.py
@@ -67,7 +67,7 @@ class Article(BaseModel):
         return self.destinations.split(',')
 
     def view_count(self):
-        TrackArticleView.objects.filter(article = self)
+        return TrackArticleView.objects.filter(article = self).count()
 
 class Feedback(BaseModel):
     article = models.ForeignKey(Article, on_delete=models.CASCADE)


### PR DESCRIPTION
The main function of this PR is to add the TrackArticleView model to Django Admin View and in this way be able to verify which articles were visited and how the user reached them.

![image](https://github.com/dtinit/portmap/assets/71613005/e901d125-40eb-4fae-ac86-7e2105a846d0)

Each visit to an article increments the corresponding count field displayed in the Admin View.

I'm currently working on a better way to filter.