### PR TITLE
Update deployment workflow to be dispatchable from outside the repository

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,19 +1,18 @@
-name: Django CI
+name: Django CI/CD
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  repository_dispatch:
+    types: [content_update]
   workflow_dispatch:
 
 jobs:
   test-python:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.11]
+
     services:
       postgres:
         image: postgres:15
@@ -31,10 +30,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
 
     - name: Install Dependencies
       run: |
@@ -82,7 +81,9 @@ jobs:
     # This workflow is used to check PRs, in which case we don't want to deploy.
     # Ensure we only deploy after a push to the main branch, or when triggered manually.
     if: |
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'repository_dispatch') &&
       github.ref == 'refs/heads/main'
     # Don't deploy unless these jobs ran successfully.
     needs: [test-python, lint-js, check-js-formatting]


### PR DESCRIPTION
Related to #78.

Updates the workflow file to be trigger-able with [`repository_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch), so we can trigger it from the portability-articles repo when content changes.

We don't actually need to do a full redeploy when portability-articles changes; we just need to repopulate the articles and regenerate index.html (`manage.py refresh`) on the live instance, which is the approach I started with for this ticket. However, that was turning out to be much more work than just redeploying, and I don't see any harm in just doing a full deployment every time.