### PR TITLE
Switch to pycmarkgfm for converting markdown to HTML

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import json
-import markdown
+import pycmarkgfm
 from allauth.account.views import LoginView as AllAuthLoginView
 from django.conf import settings
 from django.contrib import messages
@@ -129,7 +129,7 @@ def login_as_user(request):
 
 def display_article(request, article_name):
     article = Article.objects.get(name=article_name)
-    html = mark_safe(markdown.markdown(article.body))
+    html = mark_safe(pycmarkgfm.gfm_to_html(article.body))
     context = {'article': article,
                'article_body_html': html,
                'article_name': article_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ django-debug-toolbar==4.1.0
 django-environ==0.11.2
 pyyaml==6.0.1
 jwt==1.3.1
-markdown==3.5.1
 pytest-factoryboy==2.5.1
 pytest-django==4.7.0
 django-environ==0.11.2
 pytest-playwright==0.4.4
+pycmarkgfm==1.2.1


### PR DESCRIPTION
Closes #94.

Changes our Markdown library to more closely match GitHub, so articles will look the same in GitHub and on Portmap.

**Fixed list:**
![image](https://github.com/dtinit/portmap/assets/6510436/7bbe6d71-355b-411f-9ff9-1c7dbbe5ce08)

I glanced through every article and didn't see any obvious issues.