### PR TITLE
Rss feed updates

### DIFF
--- a/portmap/core/admin.py
+++ b/portmap/core/admin.py
@@ -26,6 +26,19 @@ admin_site._registry.update(admin.site._registry)
 class ArticleAdmin(admin.ModelAdmin):
     list_display = ("name", "datatype", "title", "source_list", "destination_list", "view_count", )
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(
+            _view_count=Count("trackarticleview", distinct=True),
+        )
+        return queryset
+    
+    def view_count(self, obj):
+        return obj._view_count
+    
+    view_count.admin_order_field = '_view_count'
+
+
     def get_urls(self):
         urls = super().get_urls()
         urls = [path("populate/", self.admin_site.admin_view(self.populate)),

--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import json
-from django.db.models.base import Model
-import requests
+import markdown2
 import pycmarkgfm
 from allauth.account.views import LoginView as AllAuthLoginView
 from django.utils.feedgenerator import DefaultFeed
@@ -239,15 +238,26 @@ class RssFeed(Feed):
         for article in Article.objects.all():
             title = article.title
             body = article.body
+            html_body = markdown2.markdown(body)
             html_url = article.get_absolute_url()
+            created_at = article.created_at
+            updated_at = article.updated_at
 
             parsed_articles.append({
                 "title": title,
-                "body": body,
-                "html_url": html_url
+                "body": html_body,
+                "html_url": html_url,
+                "created_at": created_at,
+                "updated_at": updated_at
             })
 
         return parsed_articles
     
     def item_link(self, item):
         return self.portmap_link + item["html_url"]
+    
+    def item_pubdate(self, item):
+        return item["created_at"]
+
+    def item_updateddate(self, item):
+        return item["updated_at"]

--- a/portmap/urls.py
+++ b/portmap/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     path('usecase_feedback', views.usecase_feedback, name='usecase_feedback'),
     path("articles/<article_name>/", views.display_article, name="display_article"),
     path("find_articles", views.find_articles, name="find_articles"),
-    path("articles_feed/", views.RssFeed(), name="latest_articles"),
+    path("rss/", views.RssFeed(), name="latest_articles"),
     # core
     path("about", views.about, name="about"),
     path("csrf_token", views.csrf_token, name="csrf_token"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytest-django==4.7.0
 django-environ==0.11.2
 pytest-playwright==0.4.4
 pycmarkgfm==1.2.1
+markdown2==2.4.13

--- a/templates/core/article_list.html
+++ b/templates/core/article_list.html
@@ -3,12 +3,12 @@
 {% load i18n %}
 {% block full_title %}{{ PROJECT_NAME }}{% endblock full_title %}
 {% block content %}
+<script src="https://unpkg.com/lucide@latest"></script>
 <section class="page page--wide">
     {% include "includes/nav-bar.html" with route="articles" %}
     {% include "includes/messages.html" %}
-    <table>
-   <tr>
-       <th>{% if title %}{{title}}{% else %}Articles{% endif %}</th>
+    <table><tr>
+       <th>{% if title %}{{title}}{% else %}Articles{% endif %}<a href="/rss"><i data-lucide="rss"></i></a></th>
    </tr>
    {% for item in articles %}
        <tr>
@@ -26,4 +26,7 @@
     </form>
 {% endif %}
 </section>
+<script>
+    lucide.createIcons();
+</script>
 {% endblock content %}


### PR DESCRIPTION
- URL to access RSS Feed changed from https://portmap.dtinit.org/articles_feed/ to simply https://portmap.dtinit.org/rss/
- There is a button now in https://portmap.dtinit.org/find_articles that will redirect the user to the RSS Feed.
- `created_at` field was added as suggested.
- HTML is now being display instead of markdown in the RSS Feed. This should allow us to display it as expected when reading it on a RSS reader such as Feedly.
- Lastly, we can now sort the View Count field in the Article Admin View.
<img width="139" alt="image" src="https://github.com/dtinit/portmap/assets/71613005/832e638b-33ff-4ce9-ba55-89291d7488a2">

Still working in a way to allow sort by `created_at` in the RSS Feed.

Closes #100 and Closes #97 