### PR TITLE
Add analytics for admins

### DIFF
--- a/portmap/core/admin.py
+++ b/portmap/core/admin.py
@@ -1,11 +1,14 @@
 from django.contrib import admin
 from django.contrib.admin.decorators import register
 from django.contrib.auth.admin import UserAdmin
+from django.contrib.admin.views.decorators import staff_member_required
+import json
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import path
 from django.db import connection
 from django.db.models import Count
+from django.template.response import TemplateResponse
 
 from .forms import UserChangeForm, UserCreationForm
 from .models import User, Article, Feedback, QueryLog, UseCaseFeedback, DataType, TrackArticleView
@@ -17,10 +20,13 @@ class PortmapAdminSite(admin.AdminSite):
     class Meta:
         pass
 
+    def get_urls(self):
+        urls = super().get_urls()
+        urls = [path("analytics", analytics), *urls]
+        return urls
 
 admin_site = PortmapAdminSite(name="portmap_admin")
 admin_site._registry.update(admin.site._registry)
-
 
 @register(Article, site=admin_site)
 class ArticleAdmin(admin.ModelAdmin):
@@ -62,4 +68,54 @@ class CustomUserAdmin(UserAdmin):
 
 @register(TrackArticleView, site=admin_site)
 class TrackArticleViewAdmin(admin.ModelAdmin):
-    list_display = ("article", "article_path", "visited_directly", "external_referrer", )  
+    list_display = ("article", "article_path", "visited_directly", "external_referrer", )
+
+@staff_member_required
+def analytics(request):
+    datatype_interest_counts = {}
+    datatype_provider_query_counts = {}
+
+    for article in Article.objects.all():
+        if article.datatype not in datatype_interest_counts:
+            datatype_interest_counts[article.datatype] = {
+                'views': 0,
+                'queries': 0
+            }
+
+    for query in QueryLog.objects.all():
+        # Query logs have datatypes stored
+        # with underscores instead of spaces
+        datatype_name = " ".join(query.datatype.split("_"))
+        if datatype_name in datatype_interest_counts:
+             datatype_interest_counts[datatype_name]['queries'] += 1
+
+        if datatype_name not in datatype_provider_query_counts:
+            datatype_provider_query_counts[datatype_name] = {
+                'sources': {},
+                'destinations': {},
+                'transitions': {}
+            }
+        if query.source in datatype_provider_query_counts[datatype_name]['sources']:
+            datatype_provider_query_counts[datatype_name]['sources'][query.source] += 1;
+        else:
+            datatype_provider_query_counts[datatype_name]['sources'][query.source] = 1;
+
+        destination = query.destination if query.destination else 'None selected'
+        if destination in datatype_provider_query_counts[datatype_name]['destinations']:
+            datatype_provider_query_counts[datatype_name]['destinations'][destination] += 1;
+        else:
+            datatype_provider_query_counts[datatype_name]['destinations'][destination] = 1;
+
+        transition = query.source + ' -> ' + destination
+
+        if transition in datatype_provider_query_counts[datatype_name]['transitions']:
+            datatype_provider_query_counts[datatype_name]['transitions'][transition] += 1
+        else:
+            datatype_provider_query_counts[datatype_name]['transitions'][transition] = 1
+
+    for view in TrackArticleView.objects.select_related("article").all():
+        datatype_interest_counts[view.article.datatype]['views'] += 1
+
+    return TemplateResponse(request, "admin/analytics.html", {'stats': json.dumps({'datatypeInterest': datatype_interest_counts, 'providerQueriesByDatatype': datatype_provider_query_counts})})
+
+

--- a/static/css/admin/analytics.css
+++ b/static/css/admin/analytics.css
@@ -1,0 +1,7 @@
+ul.tab-list {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}

--- a/static/js/admin/analytics.js
+++ b/static/js/admin/analytics.js
@@ -1,0 +1,100 @@
+/* global Chart, stats */
+// (provided by Chart.js and Django, respectively)
+
+(() => {
+  const createDatatypeInterestChart = (data) => {
+    new Chart(document.getElementById('queried-datatypes'), {
+      type: 'bar',
+      data: {
+        labels: data.map(([datatype]) => datatype),
+        datasets: [
+          {
+            label: 'Queries',
+            data: data.map(([, { queries }]) => queries),
+          },
+          {
+            label: 'Views',
+            data: data.map(([, { views }]) => views),
+          },
+        ],
+      },
+      options: {
+        scales: {
+          x: {
+            stacked: true,
+          },
+          y: {
+            stacked: true,
+          },
+        },
+      },
+    });
+  };
+
+  const createDatatypeDetailCharts = (datatype, data) => {
+    ['sources', 'destinations', 'transitions'].forEach((queryCountName) => {
+      const previousChart = Chart.getChart(`datatype-${queryCountName}`);
+      if (previousChart) {
+        previousChart.destroy();
+      }
+
+      const sortedData =
+        data && data[queryCountName]
+          ? Object.entries(data[queryCountName])
+              .slice()
+              .sort(([, a], [, b]) => b - a)
+          : [];
+
+      new Chart(document.getElementById(`datatype-${queryCountName}`), {
+        type: 'bar',
+        data: {
+          labels: sortedData.map(([datatype]) => datatype),
+          datasets: [
+            {
+              label: 'Queries',
+              data: sortedData.map(([, queryCount]) => queryCount),
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: {
+              display: true,
+              text: `Queried ${datatype} ${queryCountName}`,
+            },
+          },
+        },
+      });
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const data = Object.entries(stats.datatypeInterest)
+      .slice()
+      // Sort them by descending interest (queries + views)
+      .sort(
+        ([, aCounts], [, bCounts]) =>
+          bCounts.views + bCounts.queries - aCounts.views - aCounts.queries
+      );
+
+    createDatatypeInterestChart(data);
+
+    const tabList = document.getElementById('src-dest-tab-list');
+    data.forEach(([datatype], i) => {
+      const buttonEl = document.createElement('button');
+      buttonEl.innerText = datatype;
+      buttonEl.addEventListener('click', () => {
+        createDatatypeDetailCharts(
+          datatype,
+          stats.providerQueriesByDatatype[datatype]
+        );
+      });
+      const liEl = document.createElement('li');
+      liEl.append(buttonEl);
+      tabList.append(liEl);
+      if (i === 0) {
+        buttonEl.click();
+      }
+    });
+  });
+})();

--- a/static/js/admin/analytics.js
+++ b/static/js/admin/analytics.js
@@ -27,6 +27,7 @@
             stacked: true,
           },
         },
+        responsive: false,
       },
     });
   };
@@ -63,6 +64,7 @@
               text: `Queried ${datatype} ${queryCountName}`,
             },
           },
+          responsive: false,
         },
       });
     });

--- a/templates/admin/analytics.html
+++ b/templates/admin/analytics.html
@@ -1,0 +1,21 @@
+{% load static %} {% block header %}
+<script
+    src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"
+    integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+></script>
+<link rel="stylesheet" href="{% static 'css/admin/analytics.css' %}" />
+{% endblock header %}
+
+<h1>Datatype interest</h1>
+<canvas id="queried-datatypes"></canvas>
+<h1>Queried source and destinations by datatype</h1>
+<ul id="src-dest-tab-list" class="tab-list"></ul>
+<canvas id="datatype-sources"></canvas>
+<canvas id="datatype-destinations"></canvas>
+<canvas id="datatype-transitions"></canvas>
+<script>
+    window.stats = JSON.parse('{{ stats | safe }}');
+</script>
+<script src="{% static 'js/admin/analytics.js' %}"></script>

--- a/templates/admin/analytics.html
+++ b/templates/admin/analytics.html
@@ -9,12 +9,14 @@
 {% endblock header %}
 
 <h1>Datatype interest</h1>
-<canvas id="queried-datatypes"></canvas>
+<canvas id="queried-datatypes" width="800"></canvas>
 <h1>Queried source and destinations by datatype</h1>
 <ul id="src-dest-tab-list" class="tab-list"></ul>
-<canvas id="datatype-sources"></canvas>
-<canvas id="datatype-destinations"></canvas>
-<canvas id="datatype-transitions"></canvas>
+<canvas id="datatype-sources" width="800"></canvas>
+<br >
+<canvas id="datatype-destinations" width="800"></canvas>
+<br >
+<canvas id="datatype-transitions" width="800"></canvas>
 <script>
     window.stats = JSON.parse('{{ stats | safe }}');
 </script>


### PR DESCRIPTION
Sorta kinda closes #102.

I wasn't able to find a way to use Streamlit without setting up a Streamlit server (see https://github.com/dtinit/portmap/issues/102#issuecomment-2135880526), and I felt this would really complicate our setup just to add some exploratory charts. Instead, I created a few charts using a regular ol' Django view and JavaScript.

The view is accessible at `/dj-admin/analytics` (TODO: add a link from the admin portal?) and requires "staff member" permissions to view (super admin works too).

:rotating_light: **These screenshots show data from my local db; not production!** :rotating_light: 
![Screenshot from 2024-06-03 12-41-23](https://github.com/dtinit/portmap/assets/6510436/27558fa2-1f70-4375-a42f-c979d18d3580)
![Screenshot from 2024-06-03 12-41-30](https://github.com/dtinit/portmap/assets/6510436/734f2d75-43f8-47a7-a98f-300a8b999af7)
