### PR TITLE
Re-organizes the get articles code so that errors aren't nested

### DIFF
--- a/portmap/core/articles.py
+++ b/portmap/core/articles.py
@@ -11,33 +11,37 @@ from portmap.github_auth import get_github_auth_token
 from .views import render_index_to_string
 
 
+def process_article(article_item, article_content):
+    try:
+        yaml_header, body = extract_yaml_and_body(article_content)
+        new_data = {'body': body,
+                    'title': yaml_header['title'],
+                    'datatype': yaml_header['datatype'],
+                    'sources': yaml_header['sources'],
+                    'destinations': yaml_header['destinations']}
+        Article.objects.update_or_create(name=article_item['name'], defaults=new_data)
+
+    except Exception as e:
+        logging.error(f"Error processing article {article_item['name']}: {e}")
+        raise RuntimeError(f"Failed to process article '{article_item['name']}'. Check for headers and datatype values.")
+
+
 def get_content_files():
-    debug_articles_info = []
     gh = GithubClient()
     try:
         datatype_help = gh.get_datatype_help()
         for datatype_name in gh.get_datatype_help():
             helpText = datatype_help.get(datatype_name)
             DataType.objects.update_or_create(name=datatype_name, helpText=helpText)
-
+        article_data = {}
         for article_item in gh.get_article_list():
-            try:
-                article_content = gh.get_article(article_item['name'])
-                yaml_header, body = extract_yaml_and_body(article_content)
-                article_dict = {**yaml_header, "Article": article_item['name'], "Body": body}
-                debug_articles_info.append(article_dict)
-                new_data = {'body': body,
-                            'title': yaml_header['title'],
-                            'datatype': yaml_header['datatype'],
-                            'sources': yaml_header['sources'],
-                            'destinations': yaml_header['destinations']}
-                Article.objects.update_or_create(name=article_item['name'], defaults=new_data)
-            except Exception as e:
-                logging.error(f"Error processing article {article_item['name']}: {e}")
-                raise RuntimeError(f"Failed to process article '{article_item['name']}'. Check for headers and datatype values.")
+            article_data[article_item['name']] = gh.get_article(article_item['name'])
     except Exception as e:
         logging.error(f"Error accessing Github API: {e}")
         raise RuntimeError("Failed to access Github API.")
+
+    for article_name, article_body in article_data:
+        process_article(article_name, article_body)
 
     # Generate a static copy of the root index.html
     try:
@@ -50,7 +54,6 @@ def get_content_files():
         logging.error(f"Error generating index file: {e}")
         raise RuntimeError("Failed to generate index file")
 
-    return debug_articles_info
 
 class GithubClient:
     REPOSITORY_URL = "https://api.github.com/repos/dtinit/portability-articles"

--- a/portmap/core/articles.py
+++ b/portmap/core/articles.py
@@ -11,7 +11,7 @@ from portmap.github_auth import get_github_auth_token
 from .views import render_index_to_string
 
 
-def process_article(article_item, article_content):
+def process_article(article_name, article_content):
     try:
         yaml_header, body = extract_yaml_and_body(article_content)
         new_data = {'body': body,
@@ -19,11 +19,11 @@ def process_article(article_item, article_content):
                     'datatype': yaml_header['datatype'],
                     'sources': yaml_header['sources'],
                     'destinations': yaml_header['destinations']}
-        Article.objects.update_or_create(name=article_item['name'], defaults=new_data)
+        Article.objects.update_or_create(name=article_name, defaults=new_data)
 
     except Exception as e:
-        logging.error(f"Error processing article {article_item['name']}: {e}")
-        raise RuntimeError(f"Failed to process article '{article_item['name']}'. Check for headers and datatype values.")
+        logging.error(f"Error processing article {article_name}: {e}")
+        raise RuntimeError(f"Failed to process article '{article_name}'. Check for headers and datatype values.")
 
 
 def get_content_files():
@@ -40,7 +40,7 @@ def get_content_files():
         logging.error(f"Error accessing Github API: {e}")
         raise RuntimeError("Failed to access Github API.")
 
-    for article_name, article_body in article_data:
+    for article_name, article_body in article_data.items():
         process_article(article_name, article_body)
 
     # Generate a static copy of the root index.html

--- a/tests/core/test_gh_articles.py
+++ b/tests/core/test_gh_articles.py
@@ -6,13 +6,6 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def article_info():
-    return {
-       'name': "watch_history1.md"
-    }
-
-
-@pytest.fixture
 def article_content():
     return """
 ---
@@ -31,13 +24,13 @@ Here are some instructions!
     """
 
 
-def test_process_article(article_info, article_content):
-    process_article(article_info, article_content)
+def test_process_article(article_content):
+    process_article('watch_history1.md', article_content)
     assert Article.objects.count() == 1
 
 
-def test_process_bad_yaml(article_info, article_content):
+def test_process_bad_yaml(article_content):
     # Adding an extra comma at the end of the destinations list:
     article_content = article_content.replace('["Exampletok", "Sometube"]', '["Exampletok", "Sometube"],')
     with pytest.raises(RuntimeError) as err_info:
-        process_article(article_info, article_content)
+        process_article('watch_history1.md', article_content)

--- a/tests/core/test_gh_articles.py
+++ b/tests/core/test_gh_articles.py
@@ -1,0 +1,43 @@
+import pytest
+from portmap.core.articles import process_article
+from portmap.core.models import Article
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def article_info():
+    return {
+       'name': "watch_history1.md"
+    }
+
+
+@pytest.fixture
+def article_content():
+    return """
+---
+title:  Download your watch history
+datatype: "Viewing History"
+sources: Fakestagram
+destinations: ["Exampletok", "Sometube"]
+---
+
+# Download your watch history
+
+Here are some instructions!
+
+* An instruction
+* Another bullet point
+    """
+
+
+def test_process_article(article_info, article_content):
+    process_article(article_info, article_content)
+    assert Article.objects.count() == 1
+
+
+def test_process_bad_yaml(article_info, article_content):
+    # Adding an extra comma at the end of the destinations list:
+    article_content = article_content.replace('["Exampletok", "Sometube"]', '["Exampletok", "Sometube"],')
+    with pytest.raises(RuntimeError) as err_info:
+        process_article(article_info, article_content)


### PR DESCRIPTION
In running the inner error (with YAML parsing) was getting swallowed by the outer one (reporting a Github API issue)

With this reorganization, the errors are no longer nested, and also the article parsing section is easier to test standalone, we don't even have to mock out github client

This fixes #114 