### PR TITLE
Improve E2E debug experience

### DIFF
--- a/tests/e2e/playwright_test_suite.py
+++ b/tests/e2e/playwright_test_suite.py
@@ -1,0 +1,36 @@
+import os
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from playwright.sync_api import sync_playwright
+
+# Sets up playwright and ensures tests don't throw client-side errors
+class PlaywrightTestSuite(StaticLiveServerTestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+        super().setUpClass()
+        cls.playwright = sync_playwright().start()
+        cls.browser = cls.playwright.chromium.launch(
+            headless=True # Change to False to observe tests running in Chromium locally
+        )
+        cls.context = cls.browser.new_context(base_url=cls.live_server_url)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.browser.close()
+        cls.playwright.stop()
+
+    # Define a new page object for each test and listen for errors
+    def setUp(self):
+        self.page = self.context.new_page()
+        self.page_errors = [];
+        self.page.on("pageerror", lambda exception: self.page_errors.append(exception))
+        self.console_errors = [];
+        self.page.on("console", lambda msg: self.console_errors.append(f"{msg.text}") if msg.type == "error" else None)
+
+    # Assert no uncaught errors were thrown, otherwise report them to the console
+    def tearDown(self):
+        self.page.close()
+        assert len(self.page_errors) == 0, f"Uncaught page errors: {self.page_errors}"
+        assert len(self.console_errors) == 0, f"Uncaught JS console errors: {self.console_errors}"
+

--- a/tests/e2e/test_article.py
+++ b/tests/e2e/test_article.py
@@ -1,41 +1,22 @@
-import re
-import os
-import pytest
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from playwright.sync_api import expect, sync_playwright
+from playwright.sync_api import expect
 from portmap.core.models import Article, Feedback
 from tests.core.fixtures.factories import ArticleFactory
+from .playwright_test_suite import PlaywrightTestSuite
 
 # Tests for articles
 
-class ArticleTests(StaticLiveServerTestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-        super().setUpClass()
-        cls.playwright = sync_playwright().start()
-        cls.browser = cls.playwright.chromium.launch()
-        cls.context = cls.browser.new_context(base_url=cls.live_server_url)
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        cls.browser.close()
-        cls.playwright.stop()
-
+class ArticleTests(PlaywrightTestSuite):
     def test_reaction_form_requires_selection(self):
         article = ArticleFactory()
-        page = self.context.new_page()
-        page.goto('/articles/' + article.name + '/')
-        expect(page.locator('form#query_form textarea[name=explanation]')).to_be_hidden()
+        self.page.goto('/articles/' + article.name + '/')
+        expect(self.page.locator('form#query_form textarea[name=explanation]')).to_be_hidden()
 
     def test_happy_reaction(self):
         article = ArticleFactory()
-        page = self.context.new_page()
-        page.goto('/articles/' + article.name + '/')
-        page.locator('form#query_form input[value=happy]').click()
-        page.get_by_text('Give feedback').click();
-        expect(page).to_have_url('/articles/' + article.name + '/feedback')
+        self.page.goto('/articles/' + article.name + '/')
+        self.page.locator('form#query_form input[value=happy]').click()
+        self.page.get_by_text('Give feedback').click();
+        expect(self.page).to_have_url('/articles/' + article.name + '/feedback')
         feedbackCollection = Feedback.objects.all()
         assert len(feedbackCollection) == 1
         newFeedback = feedbackCollection.first()
@@ -44,11 +25,10 @@ class ArticleTests(StaticLiveServerTestCase):
 
     def test_sad_reaction(self):
         article = ArticleFactory()
-        page = self.context.new_page()
-        page.goto('/articles/' + article.name + '/')
-        page.locator('form#query_form input[value=sad]').click()
-        page.get_by_text('Give feedback').click();
-        expect(page).to_have_url('/articles/' + article.name + '/feedback')
+        self.page.goto('/articles/' + article.name + '/')
+        self.page.locator('form#query_form input[value=sad]').click()
+        self.page.get_by_text('Give feedback').click();
+        expect(self.page).to_have_url('/articles/' + article.name + '/feedback')
         feedbackCollection = Feedback.objects.all()
         assert len(feedbackCollection) == 1
         newFeedback = feedbackCollection.first()
@@ -58,12 +38,11 @@ class ArticleTests(StaticLiveServerTestCase):
     def test_reaction_explanation(self):
         mock_explanation = 'TEST FEEDBACK FROM PLAYWRIGHT'
         article = ArticleFactory()
-        page = self.context.new_page()
-        page.goto('/articles/' + article.name + '/')
-        page.locator('form#query_form input[value=happy]').click()
-        page.locator('form#query_form textarea[name=explanation]').fill(mock_explanation)
-        page.get_by_text('Give feedback').click();
-        expect(page).to_have_url('/articles/' + article.name + '/feedback')
+        self.page.goto('/articles/' + article.name + '/')
+        self.page.locator('form#query_form input[value=happy]').click()
+        self.page.locator('form#query_form textarea[name=explanation]').fill(mock_explanation)
+        self.page.get_by_text('Give feedback').click();
+        expect(self.page).to_have_url('/articles/' + article.name + '/feedback')
         feedbackCollection = Feedback.objects.all()
         assert len(feedbackCollection) == 1
         newFeedback = feedbackCollection.first()

--- a/tests/e2e/test_find_articles.py
+++ b/tests/e2e/test_find_articles.py
@@ -1,27 +1,12 @@
-import os
 import pytest
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from playwright.sync_api import expect, sync_playwright
+from playwright.sync_api import expect
 from portmap.core.models import UseCaseFeedback, Article
 from tests.core.fixtures.factories import ArticleFactory
+from .playwright_test_suite import PlaywrightTestSuite
 
 # Tests for the find_articles query
 
-class FindArticlesTests(StaticLiveServerTestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-        super().setUpClass()
-        cls.playwright = sync_playwright().start()
-        cls.browser = cls.playwright.chromium.launch()
-        cls.context = cls.browser.new_context(base_url=cls.live_server_url)
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        cls.browser.close()
-        cls.playwright.stop()
-
+class FindArticlesTests(PlaywrightTestSuite):
     # When there are multiple matching articles,
     # the user is presented a list to choose from and a feedback form.
     @pytest.mark.django_db
@@ -34,14 +19,13 @@ class FindArticlesTests(StaticLiveServerTestCase):
             destinations=article1.destinations
         )
 
-        page = self.context.new_page()
-        page.goto('/find_articles?datatype=' + article1.datatype
+        self.page.goto('/find_articles?datatype=' + article1.datatype
                   + '&datasource=' + article1.sources
                   + '&datadest=' + article1.destinations)
 
-        page.locator('form#multiple_option_feedback_form textarea').fill(mock_explanation)
-        page.get_by_text('Give Feedback').click()
-        expect(page).to_have_url('/usecase_feedback')
+        self.page.locator('form#multiple_option_feedback_form textarea').fill(mock_explanation)
+        self.page.get_by_text('Give Feedback').click()
+        expect(self.page).to_have_url('/usecase_feedback')
         feedbackCollection = UseCaseFeedback.objects.all()
         assert len(feedbackCollection) == 1
         newFeedback = feedbackCollection.first()

--- a/tests/e2e/test_index.py
+++ b/tests/e2e/test_index.py
@@ -1,43 +1,21 @@
 import re
-import os
 import pytest
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from playwright.sync_api import expect, sync_playwright
+from playwright.sync_api import expect
 from portmap.core.articles import get_content_files
 from portmap.core.models import UseCaseFeedback, Article, DataType
+from .playwright_test_suite import PlaywrightTestSuite
 
 # Tests for the root index page
-
-class IndexTests(StaticLiveServerTestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-        super().setUpClass()
-        cls.playwright = sync_playwright().start()
-        cls.browser = cls.playwright.chromium.launch()
-        cls.context = cls.browser.new_context(base_url=cls.live_server_url)
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        cls.browser.close()
-        cls.playwright.stop()
-
-    def test_has_title(self):
-        page = self.context.new_page()
-        page.goto("/")
-        expect(page).to_have_title("PortMap")
-
+class IndexTests(PlaywrightTestSuite):
     # Loop through all the datatypes, sources, and destinations to validate them
     def test_datatypes_and_articles(self):
         get_content_files()
-        page = self.context.new_page()
-        page.goto("/")
+        self.page.goto("/")
 
-        datatypes = page.locator('label.radiogrid').all()
+        datatypes = self.page.locator('label.radiogrid').all()
         assert len(datatypes) > 0
-        source_dropdown = page.get_by_label('Transfer from')
-        destination_dropdown = page.get_by_label(' to', exact=True)
+        source_dropdown = self.page.get_by_label('Transfer from')
+        destination_dropdown = self.page.get_by_label(' to', exact=True)
 
         def validate_current_source():
             destinations = destination_dropdown.get_by_role('option').all()
@@ -46,25 +24,25 @@ class IndexTests(StaticLiveServerTestCase):
             # Loop through every destination
             for destination_index in range(1, destination_count):
                 destination_dropdown.select_option(index=destination_index)
-                with page.expect_response(re.compile("/find_articles(?:\?.*)?")) as response_info:
-                    page.get_by_text('Find Article').click()
+                with self.page.expect_response(re.compile("/find_articles(?:\?.*)?")) as response_info:
+                    self.page.get_by_text('Find Article').click()
                 query_response = response_info.value
                 # When there's only one article, we redirect to it
                 if query_response.status == 302:
-                    expect(page).to_have_url(re.compile("/articles/.*\.md/"))
-                    expect(page.locator('.page')).to_have_count(1)
+                    expect(self.page).to_have_url(re.compile("/articles/.*\.md/"))
+                    expect(self.page.locator('.page')).to_have_count(1)
                 # Otherwise, we return a list of matching articles
                 else:
                     assert query_response.ok
-                    expect(page.locator('td > a')).not_to_have_count(0)
+                    expect(self.page.locator('td > a')).not_to_have_count(0)
 
-                page.go_back()
+                self.page.go_back()
 
         def validate_datatype(datatype):
             datatype.click()
             expect(source_dropdown).to_be_enabled()
             # The destination dropdown is disabled until a source is selected
-            expect(page.get_by_label(' to', exact=True)).to_be_disabled()
+            expect(self.page.get_by_label(' to', exact=True)).to_be_disabled()
             sources = source_dropdown.get_by_role('option').all()
             source_count = len(sources)
             assert source_count > 1 # One option is a placeholder
@@ -81,12 +59,11 @@ class IndexTests(StaticLiveServerTestCase):
     @pytest.mark.django_db
     def test_usecase_feedback_form(self):
         mock_explanation = 'TEST FEEDBACK FROM PLAYWRIGHT'
-        page = self.context.new_page()
-        page.goto('/')
-        page.get_by_text("Can't see the option you're looking for?").click()
-        page.locator('form#multiple_option_feedback_form textarea').fill(mock_explanation)
-        page.get_by_text('Give Feedback').click()
-        expect(page).to_have_url('/usecase_feedback')
+        self.page.goto('/')
+        self.page.get_by_text("Can't see the option you're looking for?").click()
+        self.page.locator('form#multiple_option_feedback_form textarea').fill(mock_explanation)
+        self.page.get_by_text('Give Feedback').click()
+        expect(self.page).to_have_url('/usecase_feedback')
         feedbackCollection = UseCaseFeedback.objects.all()
         assert len(feedbackCollection) == 1
         newFeedback = feedbackCollection.first()


### PR DESCRIPTION
Closes #131.

- Creates a class `PlaywrightTestSuite` to handle things like Playwright set up, but also client-side error collection and reporting
  - Any test which generates uncaught client-side errors will fail, and the errors will be reported to the console:
![image](https://github.com/user-attachments/assets/82d73053-be67-4d12-90e2-7d19983852da)
  - I added `headless=True` in the call to `launch()` and left a comment explaining you can change it to `False` to launch Chromium with its GUI so you can actually watch the tests execute
  - I updated our test suites to subclass this
  
The diff looks bigger than it is. All I did within the actual tests is remove `page = self.context.new_page()` and replace all other instances of `page` with `self.page`.


