### PR TITLE
Dismiss duplicate articles

### DIFF
--- a/portmap/core/articles.py
+++ b/portmap/core/articles.py
@@ -33,9 +33,17 @@ def get_content_files():
         for datatype_name in gh.get_datatype_help():
             helpText = datatype_help.get(datatype_name)
             DataType.objects.update_or_create(name=datatype_name, helpText=helpText)
+        
         article_data = {}
+        seen_articles = set()
         for article_item in gh.get_article_list():
-            article_data[article_item['name']] = gh.get_article(article_item['name'])
+            article_name = article_item['name']
+            if article_name in seen_articles:
+                logging.info(f"Duplicate article found: {article_name}")
+                continue
+            seen_articles.add(article_name)
+            article_data[article_name] = gh.get_article(article_name)
+
     except Exception as e:
         logging.error(f"Error accessing Github API: {e}")
         raise RuntimeError("Failed to access Github API.")


### PR DESCRIPTION
Quick PR to avoid having articles with duplicate names we can ensure that `get_content_files` checks for duplicates before calling `process_article`.

- A set `seen_articles` is used to keep track of article names that have already been processed.
- Before processing each article, the code checks if the article name is already in the `seen_articles` set.
- If the article name is already in the set, the article is skipped.
- If the article name is not in the set, it is added to the set, and the article is processed and added to the `article_data` dictionary.

With this approach in `get_content_files`, we avoid processing duplicate articles from the GitHub API response. However, it does not skip articles that already exist in the database, ensuring that updates to articles are processed.

Closes #135 