### PR TITLE
Sanitize html clickable links feedback

### DIFF
--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -197,7 +197,7 @@ def break_url(url_text):
     The pattern captures:
         1. Optional protocol (http:// or https://)
         2. Followed by a domain name (including letters, digits, dots, hyphens)
-        3. A period, and ome pf tje listed TLDs
+        3. A period, and one of the listed TLDs
         4. Followed by zero or more non-space characters (e.g., /path)
     """
     pattern = r'((https?:\/\/)?[A-Za-z0-9.-]+\.(?:com|net|org|io|gov|edu)\b\S*)'

--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -1,4 +1,5 @@
 from functools import wraps
+import re
 import json
 import bleach
 import markdown2
@@ -184,6 +185,35 @@ def find_articles(request):
         form = QueryIndexForm(data=None, datatypes=datatypes)
         return TemplateResponse(request, "core/index.html", {'form': form, 'datatypes': datatypes})
 
+def break_url(url_text):
+    """
+    Break down URLs into segments to avoid linkification
+    and then wrap them in double quotes.
+
+    Examples:
+        "http://example.com" -> "http:// example .com"
+        "example.com"        -> "example .com"
+    
+    The pattern captures:
+        1. Optional protocol (http:// or https://)
+        2. Followed by a domain name (including letters, digits, dots, hyphens)
+        3. A period, and ome pf tje listed TLDs
+        4. Followed by zero or more non-space characters (e.g., /path)
+    """
+    pattern = r'((https?:\/\/)?[A-Za-z0-9.-]+\.(?:com|net|org|io|gov|edu)\b\S*)'
+
+    def replacer(match):
+        original_url = match.group(1)
+        # Insert a space after protocol (if present)
+        spaced_protocol = re.sub(r'(https?:\/\/)', r'\1 ', original_url)
+        # Insert a space before the TLD
+        space_tld = re.sub(r'\.(com|net|org|io|gov|edu)', r' .\1', spaced_protocol)
+        # Wrap result in double quotes
+        return f'"{space_tld}"'
+
+    # Replace all occurences of the pattern with the split/wrapped version
+    return re.sub(pattern, replacer, url_text)
+    
 
 @ux_requires_post
 def article_feedback(request, article_name):
@@ -194,9 +224,7 @@ def article_feedback(request, article_name):
         Feedback.objects.create(article=Article.objects.get(name=article_name),
                                 reaction=form.cleaned_data['reaction'],
                                 explanation=sanitized_explanation)
-        # Turn http into hxxp to prevent Slack from unfurling the link
-        safe_for_slack = sanitized_explanation.replace("http://", "hxxp://").replace("https://", "hxxps://")
-        message = f"*New article feedback for \"{article_name}\"*:\n\nReaction: {form.cleaned_data['reaction']}\n\n{safe_for_slack}"
+        message = f"*Article feedback for \"{article_name}\"*:\n\nReaction: {form.cleaned_data['reaction']}"
         notify(message)
     referer = request.META.get('HTTP_REFERER', '/')
     return TemplateResponse(request, "core/thankyou.html", {'referer': referer})
@@ -210,8 +238,8 @@ def usecase_feedback(request):
         sanitized_explanation = bleach.clean(feedback.cleaned_data['explanation'], tags=[], attributes={}, strip=True)
         feedback.instance.explanation = sanitized_explanation
         feedback.save()
-        # Turn http into hxxp to prevent Slack from unfurling the link
-        safe_for_slack = sanitized_explanation.replace("http://", "hxxp://").replace("https://", "hxxps://")
+        # Break URLs into segments and wrap in double quotes
+        safe_for_slack = break_url(sanitized_explanation)
         message = f"*New use case feedback:*\n\n{safe_for_slack}"
         notify(message)
     referer = request.META.get('HTTP_REFERER', '/')

--- a/portmap/core/views.py
+++ b/portmap/core/views.py
@@ -192,7 +192,7 @@ def article_feedback(request, article_name):
         sanitized_explanation = bleach.clean(form.cleaned_data['explanation'], tags=[], attributes={}, strip=True)
         Feedback.objects.create(article=Article.objects.get(name=article_name),
                                 reaction=form.cleaned_data['reaction'],
-                                explanation=sanitized_explanation
+                                explanation=sanitized_explanation)
         message = f"*New article feedback for \"{article_name}\"*:\n\nReaction: {form.cleaned_data['reaction']}\n\n{sanitized_explanation}"
         notify(message)
     referer = request.META.get('HTTP_REFERER', '/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ django-environ==0.11.2
 pytest-playwright==0.4.4
 pycmarkgfm==1.2.1
 markdown2==2.4.13
+bleach=6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ django-environ==0.11.2
 pytest-playwright==0.4.4
 pycmarkgfm==1.2.1
 markdown2==2.4.13
-bleach=6.2.0
+bleach==6.2.0


### PR DESCRIPTION
If we want to ensure that URLs are not clickable when displayed in Slack, Django Admin or other contexts, we can use the `bleach` library to sanitize the text and remove any potential clickable URLs.

The `bleach.clean` function can be configured to remove all tags and attributes and will ensure that URLs are not clickable.

### Example Execution

1. **User Submits Feedback**:
    - Reaction: "Positive"
    - Explanation: "Check out this link: http://example.com/"
2. **Form Validation**:
    - form.is_valid() returns `True` because the data is valid.
3. **Sanitization**:
    - `bleach.clean(form.cleaned_data['explanation'], tags=[], attributes={}, strip=True)` removes any HTML tags and ensures that the URL remains as plain text.
    - The sanitized explanation becomes: "Check out this link: http://example.com/"
4. **Save to Database**:
    - A new Feedback object is created and saved to the database with the sanitized explanation.
5. **Send to Slack**:
    - The sanitized feedback message is constructed and sent to Slack as follows without being clickable:
 ```
 *New article feedback for "Article Name"*:

Reaction: Positive

Check out this link: http://example.com
```

Closes #129 

FYI. First commit was scrapped except a couple of bits and pieces.