### PR TITLE
Improve Lucide loading and error recovery

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -10,7 +10,24 @@
 <title>{% block full_title %}{% block title %}{% endblock title %} | {{ PROJECT_NAME }}{% endblock full_title %}</title>
 <meta name="description" content="Find help articles about moving your digital stuff.">
 <link rel="stylesheet" href="{% static 'css/base.css' %}">
+<script src="https://unpkg.com/lucide@latest" async id="lucide-script"></script>
 <script src="{% static 'js/htmx.min.js' %}" defer></script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // The lucide script is loaded asynchronously.
+        // If it's already loaded, initialize the icons.
+        if (window.lucide) {
+            window.lucide.createIcons();
+            return;
+        }
+        // Otherwise, wait for it to finish loading and *then* initialize.
+        document.getElementById('lucide-script').addEventListener('load', () => {
+            if (window.lucide) {
+                window.lucide.createIcons();
+            }
+        });
+    });
+</script>
 {% block header %}{% endblock header %}
 <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon-32x32.png' %}">
 <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon-16x16.png' %}">

--- a/templates/core/article.html
+++ b/templates/core/article.html
@@ -1,9 +1,6 @@
 {% extends '_base.html' %}
 {% load static %}
 {% load i18n %}
-{% block header %}
-<script src="https://unpkg.com/lucide@latest"></script>
-{% endblock header %}
 {% block full_title %}{{ article.title }}{% endblock full_title %}
 {% block content %}
 <section class="page page--wide">

--- a/templates/core/article_list.html
+++ b/templates/core/article_list.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% block full_title %}{{ PROJECT_NAME }}{% endblock full_title %}
 {% block content %}
-<script src="https://unpkg.com/lucide@latest"></script>
 <section class="page page--wide">
     {% include "includes/nav-bar.html" with route="articles" %}
     {% include "includes/messages.html" %}
@@ -26,7 +25,4 @@
     </form>
 {% endif %}
 </section>
-<script>
-    lucide.createIcons();
-</script>
 {% endblock content %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -2,9 +2,6 @@
 {% load static %}
 {% load i18n %}
 {% block full_title %}{{ PROJECT_NAME }}{% endblock full_title %}
-{% block header %}
-<script src="https://unpkg.com/lucide@latest"></script>
-{% endblock header %}
 {% block content %}
 
 <section class="page page--wide">
@@ -93,8 +90,4 @@
 <script defer data-domain="portmap.dtinit.org" src="https://plausible.io/js/script.js"></script>
 
 <script src="{% static 'js/query_form.js' %}"></script>
-<script>
- lucide.createIcons();
-</script>
-
 {% endblock content %}

--- a/templates/core/thankyou.html
+++ b/templates/core/thankyou.html
@@ -1,9 +1,6 @@
 {% extends '_base.html' %}
 {% load static %}
 {% load i18n %}
-{% block header %}
-<script src="https://unpkg.com/lucide@latest"></script>
-{% endblock header %}
 
 {% block content %}
 <section class="page page--wide">
@@ -20,8 +17,4 @@ libraries.
     <li><a href="/" class="icon-link"><i data-lucide="home"></i>Home</a></li>
 </ul>
 </section>
-
-<script>
-  lucide.createIcons();
-</script>
 {% endblock content %}


### PR DESCRIPTION
Closes #143.

I confirmed that Lucide [recommends](https://lucide.dev/guide/packages/lucide#cdn) using unkpg as a CDN. Personally I'm not a fan of unpkg for production use as they don't guarantee uptime (hence #143) but since this is just for icons and the site doesn't receive a ton of traffic, it's probably fine for now. A simple alternative would be to host lucide.min.js ourselves like we do with htmx, though that has its own drawbacks to consider. The other changes introduced in this PR are still relevant regardless of where we source Lucide from.

I consolidated our Lucide script fetching and initialization tags into the base template, so we don't have to worry about adding them to every page that wants to use icons, and it's easier to maintain the dependency going forward. I added the `async` attribute to that script tag so it will load in parallel without blocking anything, as #143 was blocking page rendering for several seconds each page load. A risk here is that the page will display without icons if Lucide is taking a long time to load, but IMO that's better than the whole page taking a long time to load because icons are missing, and search engine scoring algorithms agree. I could've used `defer` instead of `async`, but `defer` still blocks the `DOMContentLoaded` event until the script finishes, so we would've risked partially blocking interactivity for some pages: https://github.com/dtinit/portmap/blob/fb26c461bcc087275b6fefedc382a7bd79e0871d/static/js/article.js#L10

Going forward, if Lucide is unable to load for whatever reason, the page will just remain rendered without icons, which is what ultimately happens anyway if Lucide can't load.